### PR TITLE
Fix sort type changing bug #45

### DIFF
--- a/src/controlers/film-board-controler.js
+++ b/src/controlers/film-board-controler.js
@@ -145,6 +145,9 @@ export class FilmBoardController {
 
   // действия при смене сортировки
   _onSortChange(evt) {
+
+    evt.preventDefault();
+
     if (evt.target.tagName !== `A`) {
       return;
     }


### PR DESCRIPTION
When sort type was changed, browser scrolled hole page to top position. It was default brauser action, pressing 'anchor'. Fixed by prevent this default action.